### PR TITLE
Line removal fix for Apiarist's Pipe that makes it much more useful and work correctly.

### DIFF
--- a/src/main/java/buildcraft/compat/forestry/pipes/gui/GuiPropolisPipe.java
+++ b/src/main/java/buildcraft/compat/forestry/pipes/gui/GuiPropolisPipe.java
@@ -273,9 +273,9 @@ public class GuiPropolisPipe extends GuiBuildCraft {
                         }
 
                         IAlleleBeeSpecies next = (IAlleleBeeSpecies) entry2.getValue();
-//                        if (next.isSecret() && !tracker.isDiscovered(next)) {
-//                            continue;
-//                        }
+                        // if (next.isSecret() && !tracker.isDiscovered(next)) {
+                        // continue;
+                        // }
 
                         change = next;
                         break;

--- a/src/main/java/buildcraft/compat/forestry/pipes/gui/GuiPropolisPipe.java
+++ b/src/main/java/buildcraft/compat/forestry/pipes/gui/GuiPropolisPipe.java
@@ -273,9 +273,9 @@ public class GuiPropolisPipe extends GuiBuildCraft {
                         }
 
                         IAlleleBeeSpecies next = (IAlleleBeeSpecies) entry2.getValue();
-                        if (next.isSecret() && !tracker.isDiscovered(next)) {
-                            continue;
-                        }
+//                        if (next.isSecret() && !tracker.isDiscovered(next)) {
+//                            continue;
+//                        }
 
                         change = next;
                         break;


### PR DESCRIPTION
Directly Relates to these issues:
https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/13340
https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/13298

The unreliable discovery feature makes apiarist's pipes not usable for sorting many species. This should fix that problem.