### PR TITLE
Apiarist pipe improvements

### DIFF
--- a/src/main/java/buildcraft/compat/forestry/pipes/gui/GuiPropolisPipe.java
+++ b/src/main/java/buildcraft/compat/forestry/pipes/gui/GuiPropolisPipe.java
@@ -4,9 +4,6 @@ import java.util.Iterator;
 import java.util.Locale;
 import java.util.Map.Entry;
 
-import codechicken.nei.ItemPanels;
-import forestry.api.apiculture.BeeManager;
-import forestry.api.apiculture.IBee;
 import net.minecraft.client.renderer.texture.TextureMap;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
@@ -26,11 +23,14 @@ import buildcraft.core.lib.gui.GuiBuildCraft;
 import buildcraft.core.lib.gui.tooltips.ToolTip;
 import buildcraft.core.lib.gui.tooltips.ToolTipLine;
 import buildcraft.core.lib.gui.widgets.Widget;
+import codechicken.nei.ItemPanels;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import forestry.api.apiculture.BeeManager;
 import forestry.api.apiculture.EnumBeeType;
 import forestry.api.apiculture.IAlleleBeeSpecies;
 import forestry.api.apiculture.IApiaristTracker;
+import forestry.api.apiculture.IBee;
 import forestry.api.genetics.AlleleManager;
 import forestry.api.genetics.IAllele;
 import forestry.api.genetics.IAlleleSpecies;
@@ -94,12 +94,9 @@ public class GuiPropolisPipe extends GuiBuildCraft {
     public boolean handleDragNDrop(int mousex, int mousey, ItemStack draggedStack, int button) {
         int relativeX = mousex - guiLeft;
         int relativeY = mousey - guiTop;
-        return  getContainer().getWidgets().stream()
-                .filter(w -> w.isMouseOver(relativeX, relativeY))
-                .filter(w -> w instanceof SpeciesFilterSlot)
-                .findFirst()
-                .filter(value -> ((SpeciesFilterSlot) value).handleDragNDrop(draggedStack, button))
-                .isPresent();
+        return getContainer().getWidgets().stream().filter(w -> w.isMouseOver(relativeX, relativeY))
+                .filter(w -> w instanceof SpeciesFilterSlot).findFirst()
+                .filter(value -> ((SpeciesFilterSlot) value).handleDragNDrop(draggedStack, button)).isPresent();
     }
 
     class TypeFilterSlot extends Widget {
@@ -300,9 +297,9 @@ public class GuiPropolisPipe extends GuiBuildCraft {
                             }
 
                             IAlleleBeeSpecies next = (IAlleleBeeSpecies) entry2.getValue();
-//                            if (next.isSecret() && !(tracker.isDiscovered(next))) {
-//                                continue;
-//                            }
+                            // if (next.isSecret() && !(tracker.isDiscovered(next))) {
+                            // continue;
+                            // }
 
                             change = next;
                             break;

--- a/src/main/java/buildcraft/compat/forestry/pipes/gui/GuiPropolisPipe.java
+++ b/src/main/java/buildcraft/compat/forestry/pipes/gui/GuiPropolisPipe.java
@@ -15,6 +15,7 @@ import net.minecraftforge.common.util.ForgeDirection;
 import org.lwjgl.input.Keyboard;
 import org.lwjgl.opengl.GL11;
 
+import buildcraft.BuildCraftCompat;
 import buildcraft.compat.CompatModuleForestry;
 import buildcraft.compat.forestry.pipes.EnumFilterType;
 import buildcraft.compat.forestry.pipes.PipeItemsPropolis;
@@ -250,9 +251,7 @@ public class GuiPropolisPipe extends GuiBuildCraft {
 
         @Override
         public boolean handleMouseClick(int mouseX, int mouseY, int mouseButton) {
-            ItemStack neiDraggedStack = ItemPanels.itemPanel.draggedStack;
-            if (neiDraggedStack != null) {
-                // drag is handled by #handleDragNDrop
+            if (isNEIDragInProgress()) {
                 return false;
             }
             IAlleleSpecies change = null;
@@ -311,6 +310,13 @@ public class GuiPropolisPipe extends GuiBuildCraft {
             }
             pipeLogic.setSpeciesFilter(orientation, pattern, allele, change);
             return true;
+        }
+
+        private boolean isNEIDragInProgress() {
+            if (!BuildCraftCompat.isLoaded("NotEnoughItems")) return false;
+            ItemStack neiDraggedStack = ItemPanels.itemPanel.draggedStack;
+            // drag is handled by #handleDragNDrop
+            return neiDraggedStack != null;
         }
 
         public boolean handleDragNDrop(ItemStack draggedStack, int button) {

--- a/src/main/java/buildcraft/compat/forestry/pipes/gui/GuiPropolisPipe.java
+++ b/src/main/java/buildcraft/compat/forestry/pipes/gui/GuiPropolisPipe.java
@@ -11,6 +11,7 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.StatCollector;
 import net.minecraftforge.common.util.ForgeDirection;
 
+import org.lwjgl.input.Keyboard;
 import org.lwjgl.opengl.GL11;
 
 import buildcraft.compat.CompatModuleForestry;
@@ -255,6 +256,7 @@ public class GuiPropolisPipe extends GuiBuildCraft {
 
                 Iterator<Entry<String, IAllele>> it = AlleleManager.alleleRegistry.getRegisteredAlleles().entrySet()
                         .iterator();
+                IAlleleBeeSpecies beforeChosen = null;
                 while (it.hasNext()) {
                     Entry<String, IAllele> entry = it.next();
                     if (!(entry.getValue() instanceof IAlleleBeeSpecies)) {
@@ -263,22 +265,27 @@ public class GuiPropolisPipe extends GuiBuildCraft {
 
                     IAlleleBeeSpecies species = (IAlleleBeeSpecies) entry.getValue();
                     if (!species.getUID().equals(getSpecies().getUID())) {
+                        beforeChosen = species;
                         continue;
                     }
+                    // found previously chosen species
+                    if (Keyboard.isKeyDown(Keyboard.KEY_LSHIFT)) {
+                        change = beforeChosen;
+                    } else {
+                        while (it.hasNext()) {
+                            Entry<String, IAllele> entry2 = it.next();
+                            if (!(entry2.getValue() instanceof IAlleleBeeSpecies)) {
+                                continue;
+                            }
 
-                    while (it.hasNext()) {
-                        Entry<String, IAllele> entry2 = it.next();
-                        if (!(entry2.getValue() instanceof IAlleleBeeSpecies)) {
-                            continue;
+                            IAlleleBeeSpecies next = (IAlleleBeeSpecies) entry2.getValue();
+//                            if (next.isSecret() && !(tracker.isDiscovered(next))) {
+//                                continue;
+//                            }
+
+                            change = next;
+                            break;
                         }
-
-                        IAlleleBeeSpecies next = (IAlleleBeeSpecies) entry2.getValue();
-                        // if (next.isSecret() && !tracker.isDiscovered(next)) {
-                        // continue;
-                        // }
-
-                        change = next;
-                        break;
                     }
 
                     break;

--- a/src/main/java/buildcraft/compat/nei/NEIGuiHandlerBC.java
+++ b/src/main/java/buildcraft/compat/nei/NEIGuiHandlerBC.java
@@ -3,6 +3,7 @@ package buildcraft.compat.nei;
 import java.util.ArrayList;
 import java.util.List;
 
+import buildcraft.compat.forestry.pipes.gui.GuiPropolisPipe;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.item.ItemStack;
 
@@ -31,7 +32,11 @@ public class NEIGuiHandlerBC implements INEIGuiHandler {
 
     @Override
     public boolean handleDragNDrop(GuiContainer gui, int mousex, int mousey, ItemStack draggedStack, int button) {
-        return false;
+        if (gui instanceof GuiPropolisPipe)
+            return ((GuiPropolisPipe) gui).handleDragNDrop(mousex, mousey, draggedStack, button);
+        else {
+            return false;
+        }
     }
 
     @Override

--- a/src/main/java/buildcraft/compat/nei/NEIGuiHandlerBC.java
+++ b/src/main/java/buildcraft/compat/nei/NEIGuiHandlerBC.java
@@ -3,10 +3,10 @@ package buildcraft.compat.nei;
 import java.util.ArrayList;
 import java.util.List;
 
-import buildcraft.compat.forestry.pipes.gui.GuiPropolisPipe;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.item.ItemStack;
 
+import buildcraft.compat.forestry.pipes.gui.GuiPropolisPipe;
 import buildcraft.core.lib.gui.CompatGuiUtils;
 import buildcraft.core.lib.gui.GuiBuildCraft;
 import codechicken.nei.VisiblityData;


### PR DESCRIPTION
eliminate the pain of selecting species for the Apiarist pipe filters by clicking 200 times untill you reach (and go over) the target species by allowing to drag&drop directly from NEI tab (allowing easy filtering through NEI).
Also added backwards iteration through shift-left clicking

Tested on my 2.4.0 world